### PR TITLE
Add orderId/paymentRef usage example with VCO and Judopay

### DIFF
--- a/VisaCheckoutSwiftSample/ViewController.swift
+++ b/VisaCheckoutSwiftSample/ViewController.swift
@@ -14,6 +14,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var checkoutButton: VisaCheckoutButton!
     private let judoKit = JudoKit(token: "<#Your Judopay token#>", secret: "<#Your Judopay secret#>")
     private let judoId = "<#Your Judopay Id#>"
+    private let orderId = UUID().uuidString
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,45 +23,46 @@ class ViewController: UIViewController {
     }
 
     private func initVisaCheckout() {
-        /// See the documentation/headers for `PurchaseInfo` for
-        /// various ways to customize the purchase experience.
+        // See the Visa Checkout documentation for `PurchaseInfo` for various ways to customize the purchase experience.
         let purchaseInfo = PurchaseInfo(total: 10.99, currency: .gbp)
-        //purchaseInfo.promoCode = "PROMO1"
-        //purchaseInfo.discount = "0.10"
-        purchaseInfo.orderId = UUID().uuidString // replace with your orderId
         purchaseInfo.reviewAction = .pay
+        purchaseInfo.promoCode = "PROMO1"
+        purchaseInfo.discount = CurrencyAmount(decimalNumber: 1.99)
+        purchaseInfo.orderId = orderId
         checkoutButton.onCheckout(purchaseInfo: purchaseInfo, completion: visaCheckoutResultHandler)
     }
 
     private func visaCheckoutResultHandler(result: CheckoutResult) {
         switch result.statusCode {
         case .success:
-            print("CallId: \(String(describing: result.callId))")
-            print("Encrypted key: \(String(describing: result.encryptedKey))")
-            print("Payment data: \(String(describing: result.encryptedPaymentData))")
-
             if let callId = result.callId, let encryptedKey = result.encryptedKey, let encryptedPaymentData = result.encryptedPaymentData {
                 let amount = Amount(decimalNumber: 10.99, currency: .GBP)
+                let reference = Reference(consumerRef: UUID().uuidString, paymentRef: orderId)
                 let vcoResult = VCOResult(callId: callId, encryptedKey: encryptedKey, encryptedPaymentData: encryptedPaymentData)
-                if let reference = Reference(consumerRef: UUID().uuidString) {
-                    _ = try? judoKit
-                        .payment(judoId, amount: amount, reference: reference)
-                        .vcoResult(vcoResult)
-                        .completion(judoCompletionBlock)
-                }
+                _ = try? judoKit
+                    .payment(judoId, amount: amount, reference: reference)
+                    .vcoResult(vcoResult)
+                    .completion(judoCompletionBlock)
             }
         case .userCancelled:
-            print("Payment cancelled by the user")
+            print("Payment cancelled by the user. 💔")
         default:
             break
         }
     }
 
     private func judoCompletionBlock(response: Response?, error: JudoError?) {
+        var title: String
+        var message: String
         if let response = response, response.items.count > 0, response.items[0].result == .Success {
-            print("Payment successful!")
+            title = "Great Success!"
+            message = "Payment successful! 🎉"
         } else {
-            print("Oops. Something went wrong.")
+            title = "Oops"
+            message = "Something went wrong. 💥"
         }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in alert.dismiss(animated: true) }))
+        present(alert, animated: true)
     }
 }


### PR DESCRIPTION
Add other purchaseInfo samples: promoCode, discount
Significantly improve the user experience by including emojis in success/fail messages shown after payment